### PR TITLE
Build in tagging support

### DIFF
--- a/src/connection/BaseConnectionOptions.ts
+++ b/src/connection/BaseConnectionOptions.ts
@@ -175,4 +175,5 @@ export interface BaseConnectionOptions {
 
     };
 
+    readonly getMetadata?: () => Record<string, unknown>;
 }

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -449,6 +449,9 @@ export class Connection {
      */
     createQueryRunner(mode: ReplicationMode = "master"): QueryRunner {
         const queryRunner = this.driver.createQueryRunner(mode);
+        if (queryRunner.setMetadata != null && this.options.getMetadata != null) {
+          queryRunner.setMetadata(this.options.getMetadata());
+        }
         const manager = this.createEntityManager(queryRunner);
         Object.assign(queryRunner, { manager: manager });
         return queryRunner;

--- a/src/migration/Migration.ts
+++ b/src/migration/Migration.ts
@@ -26,7 +26,7 @@ export class Migration {
     name: string;
 
     /**
-     * If true, run this migration inside of a transaction.
+     * HEX: If true, run this migration inside of a transaction.
      * 
      * @default true
      */

--- a/src/migration/MigrationInterface.ts
+++ b/src/migration/MigrationInterface.ts
@@ -10,7 +10,7 @@ export interface MigrationInterface {
     name?: string;
 
     /**
-     * If true, run this migration inside of a transaction.
+     * HEX: If true, run this migration inside of a transaction.
      * 
      * @default true
      */

--- a/src/query-runner/QueryRunner.ts
+++ b/src/query-runner/QueryRunner.ts
@@ -399,4 +399,8 @@ export interface QueryRunner {
      */
     executeMemoryDownSql(): Promise<void>;
 
+    /**
+     * HEX: Set metadata for this query runner
+     */
+    setMetadata?: (metadata: Record<string, unknown>) => void;
 }


### PR DESCRIPTION
### Description

I originally wanted to do this in `EntityManagerFactory` since it would have been a bit 'cleaner' than this approach. However, doing this in the `Connection`->`PostgresQueryRunner` pipeline will make implementing rate limiting easier longer term. Also this catches nearly 100% of queries from typeorm


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.
-->

- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change

