### PR TITLE
allow overriding of migration templating

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.2.31",
       "license": "MIT",
       "dependencies": {
-        "@sqltools/formatter": "1.2.2",
         "app-root-path": "^3.0.0",
         "buffer": "^5.5.0",
         "chalk": "^4.1.0",
@@ -434,11 +433,6 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
-    },
-    "node_modules/@sqltools/formatter": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@sqltools/formatter/-/formatter-1.2.2.tgz",
-      "integrity": "sha512-/5O7Fq6Vnv8L6ucmPjaWbVG1XkP4FO+w5glqfkIsq3Xw4oyNAdJddbnYodNDAfjVUvo/rrSCTom4kAND7T1o5Q=="
     },
     "node_modules/@tediousjs/connection-string": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
     "typescript": "~3.6.0"
   },
   "dependencies": {
-    "@sqltools/formatter": "1.2.2",
     "app-root-path": "^3.0.0",
     "buffer": "^5.5.0",
     "chalk": "^4.1.0",

--- a/src/commands/MigrationGenerateCommand.ts
+++ b/src/commands/MigrationGenerateCommand.ts
@@ -1,10 +1,10 @@
 import {ConnectionOptionsReader} from "../connection/ConnectionOptionsReader";
 import {CommandUtils} from "./CommandUtils";
 import {createConnection} from "../index";
-import {MysqlDriver} from "../driver/mysql/MysqlDriver";
+import {Query} from "../driver/Query";
+import {SqlInMemory} from "../driver/SqlInMemory";
 import {camelCase} from "../util/StringUtils";
 import * as yargs from "yargs";
-import {AuroraDataApiDriver} from "../driver/aurora-data-api/AuroraDataApiDriver";
 import chalk from "chalk";
 
 /**
@@ -74,36 +74,23 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
                 logging: false
             });
 
-            const upSqls: string[] = [], downSqls: string[] = [];
-
             const connection = await createConnection(connectionOptions);
+            let sqlInMemory: SqlInMemory;
             try {
-                const sqlInMemory = await connection.driver.createSchemaBuilder().log();
-
-                // mysql is exceptional here because it uses ` character in to escape names in queries, that's why for mysql
-                // we are using simple quoted string instead of template string syntax
-                if (connection.driver instanceof MysqlDriver || connection.driver instanceof AuroraDataApiDriver) {
-                    sqlInMemory.upQueries.forEach(upQuery => {
-                        upSqls.push("        await queryRunner.query(\"" + upQuery.query.replace(new RegExp(`"`, "g"), `\\"`) + "\"" + MigrationGenerateCommand.queryParams(upQuery.parameters) + ");");
-                    });
-                    sqlInMemory.downQueries.forEach(downQuery => {
-                        downSqls.push("        await queryRunner.query(\"" + downQuery.query.replace(new RegExp(`"`, "g"), `\\"`) + "\"" + MigrationGenerateCommand.queryParams(downQuery.parameters) + ");");
-                    });
-                } else {
-                    sqlInMemory.upQueries.forEach(upQuery => {
-                        upSqls.push("        await queryRunner.query(`" + upQuery.query.replace(new RegExp("`", "g"), "\\`") + "`" + MigrationGenerateCommand.queryParams(upQuery.parameters) + ");");
-                    });
-                    sqlInMemory.downQueries.forEach(downQuery => {
-                        downSqls.push("        await queryRunner.query(`" + downQuery.query.replace(new RegExp("`", "g"), "\\`") + "`" + MigrationGenerateCommand.queryParams(downQuery.parameters) + ");");
-                    });
-                }
+                sqlInMemory = await connection.driver.createSchemaBuilder().log();
             } finally {
                 await connection.close();
             }
 
-            if (upSqls.length) {
+            if (sqlInMemory.upQueries.length) {
                 if (args.name) {
-                    const fileContent = MigrationGenerateCommand.getTemplate(args.name as any, timestamp, upSqls, downSqls.reverse());
+                    const migrationName = camelCase(args.name as any, true) + timestamp;
+                    const templater = connection.options.migrationTemplater || defaultMigrationTemplater;
+                    const fileContent = templater({
+                        name: migrationName,
+                        upQueries: sqlInMemory.upQueries,
+                        downQueries: sqlInMemory.downQueries,
+                    });
                     const path = process.cwd() + "/" + (directory ? (directory + "/") : "") + filename;
                     await CommandUtils.createFile(path, fileContent);
 
@@ -121,44 +108,29 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
             process.exit(1);
         }
     }
+}
 
-    // -------------------------------------------------------------------------
-    // Protected Static Methods
-    // -------------------------------------------------------------------------
+export interface MigrationTemplateArgs {
+    name: string;
+    upQueries: Query[];
+    downQueries: Query[];
+}
+export type MigrationTemplater = (args: MigrationTemplateArgs) => string;
+export function defaultMigrationTemplater({ name, upQueries, downQueries }: MigrationTemplateArgs): string {
+    const templateQuery = ({ query, parameters }: Query): string => 
+        "        await queryRunner.query(`" + query.replace(new RegExp("`", "g"), "\\`") + "`" + (parameters && parameters.length ? `, ${JSON.stringify(parameters)}` : "") + ");";
+    return `import { MigrationInterface, QueryRunner } from "typeorm";
 
-    /**
-     * Formats query parameters for migration queries if parameters actually exist
-     */
-    protected static queryParams(parameters: any[] | undefined): string {
-      if (!parameters || !parameters.length) {
-        return "";
-      }
-
-      return `, ${JSON.stringify(parameters)}`;
-    }
-
-    /**
-     * Gets contents of the migration file.
-     */
-    protected static getTemplate(name: string, timestamp: number, upSqls: string[], downSqls: string[]): string {
-        const migrationName = `${camelCase(name, true)}${timestamp}`;
-
-        return `import {MigrationInterface, QueryRunner} from "typeorm";
-
-export class ${migrationName} implements MigrationInterface {
-    name = '${migrationName}'
+export class ${name} implements MigrationInterface {
+    name = '${name}'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-${upSqls.join(`
-`)}
+${upQueries.map(templateQuery).join("\n")}
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-${downSqls.join(`
-`)}
+${downQueries.map(templateQuery).join("\n")}
     }
-
 }
 `;
-    }
 }

--- a/src/commands/MigrationGenerateCommand.ts
+++ b/src/commands/MigrationGenerateCommand.ts
@@ -86,7 +86,7 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
                 if (args.name) {
                     const migrationName = camelCase(args.name as any, true) + timestamp;
                     const templater = connection.options.migrationTemplater || defaultMigrationTemplater;
-                    const fileContent = templater({
+                    const fileContent = await templater({
                         name: migrationName,
                         upQueries: sqlInMemory.upQueries,
                         downQueries: sqlInMemory.downQueries,
@@ -116,7 +116,7 @@ export interface MigrationTemplateArgs {
     downQueries: Query[];
 }
 export type MigrationTemplater = (args: MigrationTemplateArgs) => string;
-export function defaultMigrationTemplater({ name, upQueries, downQueries }: MigrationTemplateArgs): string {
+export async function defaultMigrationTemplater({ name, upQueries, downQueries }: MigrationTemplateArgs): Promise<string> {
     const templateQuery = ({ query, parameters }: Query): string => 
         "        await queryRunner.query(`" + query.replace(new RegExp("`", "g"), "\\`") + "`" + (parameters && parameters.length ? `, ${JSON.stringify(parameters)}` : "") + ");";
     return `import { MigrationInterface, QueryRunner } from "typeorm";

--- a/src/commands/MigrationGenerateCommand.ts
+++ b/src/commands/MigrationGenerateCommand.ts
@@ -44,12 +44,6 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
                 alias: "config",
                 default: "ormconfig",
                 describe: "Name of the file with connection configuration."
-            })
-            .option("o", {
-                alias: "outputJs",
-                type: "boolean",
-                default: false,
-                describe: "Generate a migration file on Javascript instead of Typescript",
             });
     }
 
@@ -59,8 +53,7 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
         }
 
         const timestamp = new Date().getTime();
-        const extension = args.outputJs ? ".js" : ".ts";
-        const filename = timestamp + "-" + args.name + extension;
+        const filename = timestamp + "-" + args.name + ".ts";
         let directory = args.dir;
 
         // if directory is not set then try to open tsconfig and find default path there
@@ -126,9 +119,7 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
 
             if (upSqls.length) {
                 if (args.name) {
-                    const fileContent = args.outputJs ?
-                        MigrationGenerateCommand.getJavascriptTemplate(args.name as any, timestamp, upSqls, downSqls.reverse()) :
-                        MigrationGenerateCommand.getTemplate(args.name as any, timestamp, upSqls, downSqls.reverse());
+                    const fileContent = MigrationGenerateCommand.getTemplate(args.name as any, timestamp, upSqls, downSqls.reverse());
                     const path = process.cwd() + "/" + (directory ? (directory + "/") : "") + filename;
                     await CommandUtils.createFile(path, fileContent);
 
@@ -183,30 +174,6 @@ ${downSqls.join(`
 `)}
     }
 
-}
-`;
-    }
-
-    /**
-     * Gets contents of the migration file in Javascript.
-     */
-    protected static getJavascriptTemplate(name: string, timestamp: number, upSqls: string[], downSqls: string[]): string {
-        const migrationName = `${camelCase(name, true)}${timestamp}`;
-
-        return `const { MigrationInterface, QueryRunner } = require("typeorm");
-
-module.exports = class ${migrationName} {
-    name = '${migrationName}'
-
-    async up(queryRunner) {
-${upSqls.join(`
-`)}
-    }
-
-    async down(queryRunner) {
-${downSqls.join(`
-`)}
-    }
 }
 `;
     }

--- a/src/commands/MigrationGenerateCommand.ts
+++ b/src/commands/MigrationGenerateCommand.ts
@@ -6,7 +6,6 @@ import {camelCase} from "../util/StringUtils";
 import * as yargs from "yargs";
 import {AuroraDataApiDriver} from "../driver/aurora-data-api/AuroraDataApiDriver";
 import chalk from "chalk";
-import { format } from "@sqltools/formatter/lib/sqlFormatter";
 
 /**
  * Generates a new migration file with sql needs to be executed to update schema.
@@ -33,12 +32,6 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
             .option("d", {
                 alias: "dir",
                 describe: "Directory where migration should be created."
-            })
-            .option("p", {
-                alias: "pretty",
-                type: "boolean",
-                default: false,
-                describe: "Pretty-print generated SQL",
             })
             .option("f", {
                 alias: "config",
@@ -86,15 +79,6 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
             const connection = await createConnection(connectionOptions);
             try {
                 const sqlInMemory = await connection.driver.createSchemaBuilder().log();
-
-                if (args.pretty) {
-                    sqlInMemory.upQueries.forEach(upQuery => {
-                        upQuery.query = MigrationGenerateCommand.prettifyQuery(upQuery.query);
-                    });
-                    sqlInMemory.downQueries.forEach(downQuery => {
-                        downQuery.query = MigrationGenerateCommand.prettifyQuery(downQuery.query);
-                    });
-                }
 
                 // mysql is exceptional here because it uses ` character in to escape names in queries, that's why for mysql
                 // we are using simple quoted string instead of template string syntax
@@ -176,13 +160,5 @@ ${downSqls.join(`
 
 }
 `;
-    }
-
-    /**
-     *
-     */
-    protected static prettifyQuery(query: string) {
-        const formattedQuery = format(query, { indent: "    " });
-        return "\n" + formattedQuery.replace(/^/gm, "            ") + "\n        ";
     }
 }

--- a/src/connection/BaseConnectionOptions.ts
+++ b/src/connection/BaseConnectionOptions.ts
@@ -183,5 +183,5 @@ export interface BaseConnectionOptions {
     /**
      * HEX: allow customization of migration templating
      */
-    readonly migrationTemplater?: (args: { name: string, upQueries: { query: string, parameters?: any[] }[], downQueries: { query: string, parameters?: any[] }[] }) => string;
+    readonly migrationTemplater?: (args: { name: string, upQueries: { query: string, parameters?: any[] }[], downQueries: { query: string, parameters?: any[] }[] }) => Promise<string>;
 }

--- a/src/connection/BaseConnectionOptions.ts
+++ b/src/connection/BaseConnectionOptions.ts
@@ -179,4 +179,9 @@ export interface BaseConnectionOptions {
      * HEX: dynamically get metadata for use in query tagging
      */
     readonly getMetadata?: () => Record<string, string> | null;
+
+    /**
+     * HEX: allow customization of migration templating
+     */
+    readonly migrationTemplater?: (args: { name: string, upQueries: { query: string, parameters?: any[] }[], downQueries: { query: string, parameters?: any[] }[] }) => string;
 }


### PR DESCRIPTION
This PR updates our typeorm fork to allow the migration templating functionality (which takes lists of "up" and "down" queries and produces the migration class definition) to be overriden. The aim of this is to implement a transactionless migration generator which automatically transforms the default typeorm-generated migrations into safe transactionless migrations following the rules in the migration runbook. I structured things this way so that logic can live in our monorepo, and our fork just exposes this seam.

While I was at it I removed a couple of CLI options that we don't use and which impact the templating (`--outputJs` and `--pretty` - removing the latter allows us to drop a dependency as well). I also dropped a branch that handled quoting for MySQL to simplify.